### PR TITLE
Fix manifest add command on Windows

### DIFF
--- a/pkg/fs/manifest_service.go
+++ b/pkg/fs/manifest_service.go
@@ -103,12 +103,12 @@ func (m ManifestService) Add(manifestURIs ...string) error {
 	for _, manifestURI := range manifestURIs {
 		m.reporter.Header(fmt.Sprintf("Adding manifest from %s", manifestURI))
 
-		u, err := url.Parse(manifestURI)
+		u, validURL, err := getURL(manifestURI)
 		if err != nil {
 			return err
 		}
 
-		if u.Scheme != "" {
+		if validURL {
 			if err := m.addURL(*u); err != nil {
 				return err
 			}
@@ -221,4 +221,19 @@ func (m ManifestService) addDir(manifestDir string) error {
 		}
 	}
 	return nil
+}
+
+// getURL returns a url.URL if the given URI is a valid URL.
+// url.Parse returns a url object with the scheme populated for
+// Winddows paths, so the Host must also be checked.
+func getURL(manifestURI string) (*url.URL, bool, error) {
+	u, err := url.Parse(manifestURI)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if u.Scheme != "" && u.Host != "" {
+		return u, true, nil
+	}
+	return nil, false, nil
 }

--- a/pkg/fs/manifest_service_test.go
+++ b/pkg/fs/manifest_service_test.go
@@ -145,3 +145,54 @@ func TestManifestService_Add_from_fs(t *testing.T) {
 		})
 	}
 }
+
+func TestManifestService_Test_Get_URL(t *testing.T) {
+
+	cases := []struct {
+		name        string
+		manifestURI string
+		wanted      bool
+	}{
+		{
+			name:        "relative path is not a url",
+			manifestURI: filepath.Join("testdata", "manifests", "deploy.yaml"),
+			wanted:      false,
+		},
+		{
+			name:        "absolute unix path is not a url",
+			manifestURI: "/tmp/deploy.yaml",
+			wanted:      false,
+		},
+		{
+			name:        "absolute windows path is not a url",
+			manifestURI: "c:\\tmp\\deploy.yaml",
+			wanted:      false,
+		},
+		{
+			name:        "relative windows path is not a url",
+			manifestURI: "tmp\\deploy.yaml",
+			wanted:      false,
+		},
+		{
+			name:        "http path is a url",
+			manifestURI: "http://example.com/deploy.yaml",
+			wanted:      true,
+		},
+		{
+			name:        "https path is a url",
+			manifestURI: "https://example.com/deploy.yaml",
+			wanted:      true,
+		},
+		{
+			name:        "ws path is a url",
+			manifestURI: "ws://example.com/deploy.yaml",
+			wanted:      true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, valid, _ := getURL(tc.manifestURI)
+			require.Equal(t, tc.wanted, valid)
+		})
+	}
+}


### PR DESCRIPTION
This PR refactors the logic in pkg/fs/manifest_service.go to check url.Host when
determining if the manifestURI is a URL or not. When url.Parse is used on a windows path,
a URL is generated with a scheme populated, so the Host must also be checked.

Closes: #51

Signed-off-by: Jeremy Rickard <rickardj@vmware.com>