### PR TITLE
Add ability to do integration tests

### DIFF
--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -40,6 +40,23 @@ jobs:
       - name: Run tests
         run: go test -v -covermode=count ./...
 
+  integration-test:
+    strategy:
+      matrix:
+        go-version: [1.13.x]
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Install Go
+        if: success()
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Run tests
+        run: go test -tags=integration -v ./... -count=1
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.x
+          go-version: 1.14.x
       - name: Checkout code
         uses: actions/checkout@v1
       - name: Install golangci-lint
@@ -26,7 +26,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x]
+        go-version: [1.14.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -43,7 +43,7 @@ jobs:
   integration-test:
     strategy:
       matrix:
-        go-version: [1.13.x]
+        go-version: [1.14.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -64,7 +64,7 @@ jobs:
         if: success()
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.x
+          go-version: 1.14.x
       - name: Checkout code
         uses: actions/checkout@v1
       - name: Calc coverage
@@ -89,7 +89,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.x
+          go-version: 1.14.x
       - name: Checkout code
         uses: actions/checkout@v1
       - name: build

--- a/internal/integration/fs_helpers_test.go
+++ b/internal/integration/fs_helpers_test.go
@@ -1,0 +1,28 @@
+// +build integration
+
+/*
+ * Copyright 2020 Sheaf Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package integration_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func checkDirExists(t *testing.T, dir string) {
+	fi, err := os.Stat(dir)
+	require.NoError(t, err, "path %s does not exist", dir)
+	require.True(t, fi.IsDir(), "path %s is not a directory", dir)
+}
+
+func checkFileExists(t *testing.T, file string) {
+	fi, err := os.Stat(file)
+	require.NoError(t, err, "path %s does not exist", file)
+	require.False(t, fi.IsDir(), "path %s is not a file", file)
+}

--- a/internal/integration/harness_test.go
+++ b/internal/integration/harness_test.go
@@ -1,0 +1,74 @@
+// +build integration
+
+/*
+ * Copyright 2020 Sheaf Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+type harness struct {
+	buildDir string
+	sheafBin string
+}
+
+func newRunner(buildDir string) (*harness, error) {
+	r := harness{
+		buildDir: buildDir,
+		sheafBin: filepath.Join(buildDir, "sheaf"),
+	}
+
+	if err := r.buildSheaf(); err != nil {
+		return nil, fmt.Errorf("build sheaf: %w", err)
+	}
+
+	return &r, nil
+}
+
+func (r *harness) buildSheaf() error {
+	args := []string{
+		"build",
+		"-o", r.sheafBin,
+		"github.com/bryanl/sheaf/cmd/sheaf",
+	}
+
+	cmd := exec.Command("go", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	r.sheafBin = filepath.Join(r.buildDir, "sheaf")
+	return nil
+}
+
+func (r harness) runSheaf(workingDirectory string, args ...string) error {
+	cmd := exec.Command(r.sheafBin, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = workingDirectory
+
+	return cmd.Run()
+}
+
+func (r harness) cleanup() error {
+	if r.buildDir != "" {
+		if err := os.RemoveAll(r.buildDir); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/integration/init_test.go
+++ b/internal/integration/init_test.go
@@ -1,0 +1,117 @@
+// +build integration
+
+/*
+ * Copyright 2020 Sheaf Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package integration_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_sheaf_init(t *testing.T) {
+	bundleName := "my-bundle"
+
+	workingDirectory, err := ioutil.TempDir("", "sheaf-test")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if workingDirectory != "" {
+			err := os.RemoveAll(workingDirectory)
+			require.NoError(t, err)
+		}
+	})
+
+	cases := []struct {
+		name          string
+		bundleName    string
+		args          []string
+		runnerOptions []sheafInitRunnerOption
+	}{
+		{
+			name:       "with no options",
+			bundleName: bundleName,
+		},
+		{
+			name:       "with a bundle directory",
+			bundleName: bundleName,
+			args:       []string{"--bundle-path", "custom-dir"},
+			runnerOptions: []sheafInitRunnerOption{
+				func(initRunner sheafInitRunner) sheafInitRunner {
+					initRunner.bundlePath = "custom-dir"
+					return initRunner
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		sir := newSheafInitRunner(t, testHarness, tc.name, workingDirectory, tc.bundleName, tc.runnerOptions...)
+		sir.Run(tc.args...)
+	}
+}
+
+type sheafInitRunnerOption func(initRunner sheafInitRunner) sheafInitRunner
+
+type sheafInitRunner struct {
+	name             string
+	workingDirectory string
+	bundleName       string
+	bundlePath       string
+	harness          *harness
+	t                *testing.T
+}
+
+func newSheafInitRunner(t *testing.T, h *harness, name, wd, bundleName string, options ...sheafInitRunnerOption) *sheafInitRunner {
+	sir := sheafInitRunner{
+		t:                t,
+		name:             name,
+		workingDirectory: wd,
+		bundleName:       bundleName,
+		harness:          h,
+	}
+
+	require.NotEmpty(t, name)
+	require.NotEmpty(t, wd)
+	require.NotEmpty(t, bundleName)
+
+	for _, option := range options {
+		sir = option(sir)
+	}
+
+	return &sir
+}
+
+func (r *sheafInitRunner) Run(args ...string) {
+	r.t.Run(r.name, func(t *testing.T) {
+		args = append([]string{"init", r.bundleName}, args...)
+
+		root := filepath.Join(r.workingDirectory, r.bundleName)
+		if r.bundlePath != "" {
+			root = filepath.Join(r.workingDirectory, r.bundlePath)
+		}
+
+		err := r.harness.runSheaf(r.workingDirectory, args...)
+		require.NoError(t, err)
+
+		t.Run("creates a bundle directory", func(t *testing.T) {
+			checkDirExists(t, root)
+		})
+
+		t.Run("creates a manifests directory", func(t *testing.T) {
+			checkDirExists(t, filepath.Join(root, "app", "manifests"))
+		})
+
+		t.Run("creates a bundle configuration", func(t *testing.T) {
+			checkFileExists(t, filepath.Join(root, "bundle.json"))
+		})
+	})
+}

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2020 Sheaf Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Package integration contains integration tests for sheaf.
+package integration

--- a/internal/integration/integration_suite_test.go
+++ b/internal/integration/integration_suite_test.go
@@ -1,0 +1,61 @@
+// +build integration
+
+/*
+ * Copyright 2020 Sheaf Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package integration_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"go.uber.org/multierr"
+)
+
+var (
+	testHarness *harness
+)
+
+func TestMain(m *testing.M) {
+	code, err := run(m)
+	if err != nil {
+		log.Printf("%v", err)
+		os.Exit(code)
+	}
+
+	os.Exit(code)
+}
+
+func run(m *testing.M) (code int, err error) {
+	dir, err := ioutil.TempDir("", "build-dir")
+	if err != nil {
+		return 1, fmt.Errorf("create build directory: %w", err)
+	}
+
+	defer func() {
+		errors := []error{err}
+		if cErr := testHarness.cleanup(); cErr != nil {
+			errors = append(errors, fmt.Errorf("cleanup: %w", cErr))
+		}
+
+		err = multierr.Combine(errors...)
+	}()
+
+	testHarness, err = newRunner(dir)
+	if err != nil {
+		return 1, fmt.Errorf("creat test harness: %w", err)
+	}
+
+	code = m.Run()
+	if code != 0 {
+		return code, fmt.Errorf("non zero error code %d", code)
+	}
+
+	return code, nil
+}

--- a/pkg/archive/stager_test.go
+++ b/pkg/archive/stager_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/archive/write_test.go
+++ b/pkg/archive/write_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/commands/archive/pack.go
+++ b/pkg/commands/archive/pack.go
@@ -14,7 +14,7 @@ import (
 
 // NewPackCommand creates a pack command.
 func NewPackCommand() *cobra.Command {
-	var bundleDir string
+	var bundlePath string
 	var force bool
 
 	cmd := &cobra.Command{
@@ -28,7 +28,7 @@ func NewPackCommand() *cobra.Command {
 			}
 
 			config := fs.PackConfig{
-				BundleURI:     bundleDir,
+				BundleURI:     bundlePath,
 				BundleFactory: fs.DefaultBundleFactory,
 				Packer:        fs.NewPacker(),
 				Dest:          dest,
@@ -38,7 +38,7 @@ func NewPackCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&bundleDir, "bundle-dir", ".", "bundle directory")
+	cmd.Flags().StringVar(&bundlePath, "bundle-path", ".", "bundle path")
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite existing file")
 
 	return cmd

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -24,7 +24,7 @@ func NewInitCommand() *cobra.Command {
 		Short: "Initialize bundle directory",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return fmt.Errorf("requires path to new fs directory")
+				return fmt.Errorf("requires requires name of new bundle")
 			}
 
 			return nil
@@ -38,8 +38,8 @@ func NewInitCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&version, "version", "", "fs version")
-	cmd.Flags().StringVar(&bundlePath, "fs-path", "", "fs path")
+	cmd.Flags().StringVar(&version, "version", "", "bundle version")
+	cmd.Flags().StringVar(&bundlePath, "bundle-path", "", "bundle path")
 
 	return cmd
 }

--- a/pkg/commands/manifest/add.go
+++ b/pkg/commands/manifest/add.go
@@ -18,14 +18,14 @@ import (
 func NewAddCommand() *cobra.Command {
 	var files []string
 	var force bool
-	var bundleDir string
+	var bundlePath string
 
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "add manifest to bundle",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			b, err := fs.NewBundle(bundleDir)
+			b, err := fs.NewBundle(bundlePath)
 			if err != nil {
 				return err
 			}
@@ -49,7 +49,7 @@ func NewAddCommand() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&files, "filename", "f", nil,
 		"filename to add (can specify multiple times)")
 	cmd.Flags().BoolVar(&force, "force", false, "force (overwrite)")
-	cmd.Flags().StringVarP(&bundleDir, "bundle-dir", "d", cwd, "bundle directory")
+	cmd.Flags().StringVarP(&bundlePath, "bundle-path", "d", cwd, "bundle path")
 
 	return cmd
 }

--- a/pkg/fs/add_image_test.go
+++ b/pkg/fs/add_image_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/fs/artifacts_test.go
+++ b/pkg/fs/artifacts_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/fs/bundle_test.go
+++ b/pkg/fs/bundle_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/fs/image_replace_test.go
+++ b/pkg/fs/image_replace_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/fs/image_service_test.go
+++ b/pkg/fs/image_service_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/fs/manifest_service_test.go
+++ b/pkg/fs/manifest_service_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/fs/manifest_shower_test.go
+++ b/pkg/fs/manifest_shower_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/fs/packer_test.go
+++ b/pkg/fs/packer_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/fs/user_defined_image_deleter_test.go
+++ b/pkg/fs/user_defined_image_deleter_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/fs/user_defined_image_setter_test.go
+++ b/pkg/fs/user_defined_image_setter_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/fs/write_test.go
+++ b/pkg/fs/write_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/images/set_test.go
+++ b/pkg/images/set_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/manifest/container_test.go
+++ b/pkg/manifest/container_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/remote/write_test.go
+++ b/pkg/remote/write_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/reporter/std_test.go
+++ b/pkg/reporter/std_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/sheaf/bundle_config_test.go
+++ b/pkg/sheaf/bundle_config_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/sheaf/image_manifest_test.go
+++ b/pkg/sheaf/image_manifest_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *

--- a/pkg/sheaf/mapping_test.go
+++ b/pkg/sheaf/mapping_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
  * Copyright 2020 Sheaf Authors
  *


### PR DESCRIPTION
This change introduces a harness for running integration tests.
Initially it only tests the happy paths for `sheaf init`. Integration
tests are under an `integration` build tag.

Signed-off-by: bryanl <bryanliles@gmail.com>