### PR TITLE
Run non-registry integration tests in Windows CI

### DIFF
--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -58,7 +58,22 @@ jobs:
       - name: Run tests
         env:
           REGISTRY: localhost:${{ job.services.registry.ports['5000'] }}
-        run: go test -tags=integration -v ./... -count=1
+        run: go test -tags=integration ./... -count=1
+
+  integration-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Install Go
+        if: success()
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14.x
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Run tests
+        env:
+          REGISTRY_UNAVAILABLE: true
+        run: go test -tags=integration ./... -count=1
 
   coverage:
     runs-on: ubuntu-latest

--- a/integration/archive_test.go
+++ b/integration/archive_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pivotal/image-relocation/pkg/pathmapping"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bryanl/sheaf/internal/testutil"
 	"github.com/bryanl/sheaf/pkg/sheaf"
 )
 
@@ -47,7 +48,7 @@ func Test_sheaf_archive_pack(t *testing.T) {
 }
 
 func Test_sheaf_archive_push(t *testing.T) {
-	withWorkingDirectory(t, func(options wdOptions) {
+	withWorkingDirectoryAndMaybeRegistry(t, func(options wdOptions) {
 		b := sheafInit(t, testHarness, "integration", options.dir)
 
 		_, err := b.harness.runSheaf(b.dir, "manifest", "add",
@@ -82,7 +83,7 @@ func Test_sheaf_archive_push(t *testing.T) {
 }
 
 func Test_sheaf_archive_relocate(t *testing.T) {
-	withWorkingDirectory(t, func(options wdOptions) {
+	withWorkingDirectoryAndMaybeRegistry(t, func(options wdOptions) {
 		b := sheafInit(t, testHarness, "integration", options.dir)
 
 		_, err := b.harness.runSheaf(b.dir, "manifest", "add",
@@ -174,8 +175,7 @@ func Test_sheaf_archive_show_manifests(t *testing.T) {
 				output, err := b.harness.runSheaf(b.dir, args...)
 				require.NoError(t, err)
 
-				require.Equal(t, string(tc.wanted), output.Stdout.String())
-
+				require.Equal(t, string(testutil.NormalizeNewlines(tc.wanted)), string(testutil.NormalizeNewlines(output.Stdout.Bytes())))
 			})
 
 		})

--- a/integration/config_test.go
+++ b/integration/config_test.go
@@ -283,7 +283,7 @@ func Test_sheaf_config_get(t *testing.T) {
 }
 
 func Test_sheaf_config_push_and_pull(t *testing.T) {
-	withWorkingDirectory(t, func(options wdOptions) {
+	withWorkingDirectoryAndMaybeRegistry(t, func(options wdOptions) {
 
 		b := sheafInit(t, testHarness, "integration", options.dir)
 

--- a/integration/fs_helpers_test.go
+++ b/integration/fs_helpers_test.go
@@ -31,6 +31,27 @@ func withWorkingDirectory(t *testing.T, fn func(options wdOptions)) {
 		}
 	})
 
+	options := wdOptions{
+		dir: workingDirectory,
+	}
+
+	fn(options)
+}
+
+func withWorkingDirectoryAndMaybeRegistry(t *testing.T, fn func(options wdOptions)) {
+	// If no registry is available, skip the test.
+	if os.Getenv("REGISTRY_UNAVAILABLE") != "" {
+		return
+	}
+	workingDirectory, err := ioutil.TempDir("", "sheaf-test")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if workingDirectory != "" {
+			require.NoError(t, os.RemoveAll(workingDirectory))
+		}
+	})
+
 	registry := os.Getenv("REGISTRY")
 
 	if registry == "" {

--- a/integration/harness_test.go
+++ b/integration/harness_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 type harness struct {
@@ -22,7 +23,6 @@ type harness struct {
 func newRunner(buildDir string) (*harness, error) {
 	r := harness{
 		buildDir: buildDir,
-		sheafBin: filepath.Join(buildDir, "sheaf"),
 	}
 
 	if err := r.buildSheaf(); err != nil {
@@ -33,6 +33,12 @@ func newRunner(buildDir string) (*harness, error) {
 }
 
 func (r *harness) buildSheaf() error {
+	if runtime.GOOS == "windows" {
+		r.sheafBin = filepath.Join(r.buildDir, "sheaf.exe")
+	} else {
+		r.sheafBin = filepath.Join(r.buildDir, "sheaf")
+	}
+
 	args := []string{
 		"build",
 		"-o", r.sheafBin,
@@ -48,7 +54,6 @@ func (r *harness) buildSheaf() error {
 		return err
 	}
 
-	r.sheafBin = filepath.Join(r.buildDir, "sheaf")
 	return nil
 }
 

--- a/integration/manifest_test.go
+++ b/integration/manifest_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/bryanl/sheaf/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -172,7 +173,7 @@ func Test_sheaf_manifest_show(t *testing.T) {
 				output, err := b.harness.runSheaf(b.dir, args...)
 				require.NoError(t, err)
 
-				require.Equal(t, string(tc.wanted), output.Stdout.String())
+				require.Equal(t, string(testutil.NormalizeNewlines(tc.wanted)), string(testutil.NormalizeNewlines(output.Stdout.Bytes())))
 			})
 
 		})


### PR DESCRIPTION
Currently, a registry is not available in Windows CI.