### PR TITLE
Adopt github.com/vmware-labs/yaml-jsonpath

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492 // indirect
 	github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible // indirect
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce
-	github.com/glyn/go-yamlpath v0.0.0-20200507152037-b3d35ca052dc
 	github.com/golang/mock v1.2.0
 	github.com/golang/protobuf v1.3.3 // indirect
 	github.com/google/go-cmp v0.4.0 // indirect
@@ -25,6 +24,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.5.1
+	github.com/vmware-labs/yaml-jsonpath v0.0.0-20200601152922-422ced76f914
 	go.uber.org/multierr v1.5.0
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,6 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/glyn/go-yamlpath v0.0.0-20200507152037-b3d35ca052dc h1:SV2dvPzv7pR+tVEytzemsPaHi5gBVNBYNi3c2WPYnIU=
-github.com/glyn/go-yamlpath v0.0.0-20200507152037-b3d35ca052dc/go.mod h1:VS5ArJvBri32e87LnxRieUtYkZ9IqmhKB33RbGdqbOg=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
@@ -281,6 +279,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/vmware-labs/yaml-jsonpath v0.0.0-20200601152922-422ced76f914 h1:zDqhJXiF+EcOvFspTrU+lQsXQTs2N9U1rcvB6Ih9dm8=
+github.com/vmware-labs/yaml-jsonpath v0.0.0-20200601152922-422ced76f914/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=

--- a/pkg/manifest/container.go
+++ b/pkg/manifest/container.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/bryanl/sheaf/internal/yamlutil"
 	"github.com/bryanl/sheaf/pkg/sheaf"
-	"github.com/glyn/go-yamlpath/pkg/yamlpath"
 	"github.com/pivotal/image-relocation/pkg/image"
 	"github.com/pivotal/image-relocation/pkg/images"
+	"github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
 )
 
 // ContainerImagesFromBytes returns container images referenced in manifest bytes.
@@ -182,7 +182,7 @@ func jsonPathSearchNodes(doc *yaml.Node, query string) ([]*yaml.Node, error) {
 		return nil, fmt.Errorf("unable to parse query: %w", err)
 	}
 
-	return p.Find(doc), nil
+	return p.Find(doc)
 }
 
 func manifestDocuments(in []byte) ([]*yaml.Node, error) {

--- a/pkg/manifest/container_test.go
+++ b/pkg/manifest/container_test.go
@@ -103,7 +103,7 @@ func TestContainerImages(t *testing.T) {
 				{
 					APIVersion: "caching.internal.knative.dev/v1alpha1",
 					Kind:       "Image",
-					JSONPath:   "{.spec.image}",
+					JSONPath:   "]",
 				},
 			},
 			wantErr: true,


### PR DESCRIPTION
github.com/glyn/go-yamlpath has moved to github.com/vmware-labs/yaml-jsonpath.

Fixed one of the tests since `{.spec.image}` is now a valid JSONPath and selects the image in this, admittedly perverse, example:
```
apiVersion: caching.internal.knative.dev/v1alpha1
kind: Image
metadata:
  labels:
    serving.knative.dev/release: "v0.12.0"
  name: queue-proxy
  namespace: knative-serving
"{":
  spec:
    "image}": gcr.io/example/image1
```